### PR TITLE
lint: update tailwind.config.js

### DIFF
--- a/packages/playground/tailwind.config.js
+++ b/packages/playground/tailwind.config.js
@@ -1,7 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 export default {
 	content: ['./index.html', './src/**/*.vue', './src/**/*.ts'],
-	darkMode: false, // or 'media' or 'class'
+	darkMode: 'media', // 'media' or 'class'
 	theme: {
 		extend: {},
 	},


### PR DESCRIPTION
Remove build warning:  

> The `darkMode` option in your Tailwind CSS configuration is set to `false`, which now behaves the same as `media`. Change `darkMode` to `media` or remove it entirely.